### PR TITLE
fix: replace panicking unwraps in parsers + map anti-bot errors to 503

### DIFF
--- a/api-cfworker/src/lib.rs
+++ b/api-cfworker/src/lib.rs
@@ -14,6 +14,16 @@ fn parse_naive_date(s: &str) -> std::result::Result<NaiveDate, ParseError> {
     NaiveDate::parse_from_str(&s, "%Y-%m-%d")
 }
 
+fn map_scraper_error(msg: &str) -> Result<Response> {
+    if msg.contains("anti-bot challenge") {
+        let mut resp = Response::error("Rate limited by athletics.app, retry later", 503)?;
+        let _ = resp.headers_mut().set("Retry-After", "300");
+        Ok(resp)
+    } else {
+        Response::error(format!("Scraping error: {}", msg), 500)
+    }
+}
+
 fn format_http_timestamp(time: DateTime<Utc>) -> String {
     time.format("%a, %d %b %Y %H:%M:%S %Z").to_string()
 }
@@ -52,12 +62,12 @@ async fn main(req: Request, env: Env, ctx: Context) -> Result<Response> {
         .get_async("/competitions/results/:id", |_req, ctx| async move {
             if let Some(id) = ctx.param("id") {
                 if let Ok(id) = id.parse() {
-                    let result = atletiek_nu_api::get_athlete_event_result(id).await;
-                    match result {
+                    match atletiek_nu_api::get_athlete_event_result(id).await {
                         Ok(r) => Response::from_json(&r),
                         Err(e) => {
-                            console_error!("Error fetching results: {}", e);
-                            Response::error("Internal error", 500)
+                            let msg = e.to_string();
+                            console_error!("Error fetching results {}: {}", id, msg);
+                            map_scraper_error(&msg)
                         }
                     }
                 } else {
@@ -79,9 +89,10 @@ async fn main(req: Request, env: Env, ctx: Context) -> Result<Response> {
                 };
                 match atletiek_nu_api::search_athletes(&query).await {
                     Ok(r) => Response::from_json(&r),
-                    Err(e) =>  {
-                        console_error!("Error fetching results: {}", e);
-                        Response::error("Internal error", 500)
+                    Err(e) => {
+                        let msg = e.to_string();
+                        console_error!("Error searching athletes: {}", msg);
+                        map_scraper_error(&msg)
                     }
                 }
             } else {
@@ -91,12 +102,12 @@ async fn main(req: Request, env: Env, ctx: Context) -> Result<Response> {
         .get_async("/athletes/profile/:id", |_req, ctx| async move {
             if let Some(id) = ctx.param("id") {
                 if let Ok(id) = id.parse() {
-                    let result = atletiek_nu_api::get_athlete_profile(id).await;
-                    match result {
+                    match atletiek_nu_api::get_athlete_profile(id).await {
                         Ok(r) => Response::from_json(&r),
                         Err(e) => {
-                            console_error!("Error fetching results: {}", e);
-                            Response::error("Internal error", 500)
+                            let msg = e.to_string();
+                            console_error!("Error fetching profile {}: {}", id, msg);
+                            map_scraper_error(&msg)
                         }
                     }
                 } else {
@@ -112,8 +123,9 @@ async fn main(req: Request, env: Env, ctx: Context) -> Result<Response> {
                     match atletiek_nu_api::get_competition_registrations(&id).await {
                         Ok(r) => Response::from_json(&r),
                         Err(e) => {
-                            console_error!("Error fetching results: {}", e);
-                            Response::error("Internal error", 500)
+                            let msg = e.to_string();
+                            console_error!("Error fetching registrations {}: {}", id, msg);
+                            map_scraper_error(&msg)
                         }
                     }
                 } else {
@@ -129,8 +141,9 @@ async fn main(req: Request, env: Env, ctx: Context) -> Result<Response> {
                     match atletiek_nu_api::get_competition_registrations_web(&id).await {
                         Ok(r) => Response::from_json(&r),
                         Err(e) => {
-                            console_error!("Error fetching results: {}", e);
-                            Response::error("Internal error", 500)
+                            let msg = e.to_string();
+                            console_error!("Error fetching web registrations {}: {}", id, msg);
+                            map_scraper_error(&msg)
                         }
                     }
                 } else {
@@ -177,8 +190,9 @@ async fn main(req: Request, env: Env, ctx: Context) -> Result<Response> {
                 match atletiek_nu_api::search_competitions_for_time_period(start_date, end_date, &query).await {
                     Ok(r) => Response::from_json(&r),
                     Err(e) => {
-                        console_error!("Error searching competitions: {}", e);
-                        Response::error("Internal error", 500)
+                        let msg = e.to_string();
+                        console_error!("Error searching competitions: {}", msg);
+                        map_scraper_error(&msg)
                     }
                 }
             } else {

--- a/atletiek-nu-api/src/lib.rs
+++ b/atletiek-nu-api/src/lib.rs
@@ -75,6 +75,13 @@ pub(crate) async fn send_request(url: &str) -> anyhow::Result<String> {
 
     let text = res.text().await?;
 
+    if text.contains("challenges.cloudflare.com/turnstile")
+        || text.contains("Checking your webbrowser")
+        || text.contains("Checking your browser")
+    {
+        anyhow::bail!("athletics.app served an anti-bot challenge page (rate-limited?)");
+    }
+
     if std::env::var("ATN_DUMP_REQ").is_ok() {
         let n = rand::thread_rng().next_u64();
 

--- a/atletiek-nu-api/src/models/athlete_list.rs
+++ b/atletiek-nu-api/src/models/athlete_list.rs
@@ -32,29 +32,28 @@ pub fn parse(html: Html) -> anyhow::Result<AthleteList> {
             .filter(|v| !v.is_empty())
             .collect();
 
+        if texts.len() < 2 { continue; }
         let name = texts[0].replace("  ", " ");
         let age_and_club = texts[1];
 
-        let captures = re_age_and_club.captures_iter(&age_and_club).next().unwrap();
+        let Some(captures) = re_age_and_club.captures_iter(&age_and_club).next() else { continue };
 
         let onclick = i
             .parent()
-            .unwrap()
-            .parent()
-            .unwrap()
-            .value()
-            .as_element()
-            .unwrap()
-            .attr("onclick")
-            .unwrap();
+            .and_then(|p| p.parent())
+            .and_then(|p| p.value().as_element())
+            .and_then(|e| e.attr("onclick"));
 
-        let athlete_id: u32 = re_athlete_id.captures_iter(onclick).next().unwrap()[1].parse()?;
+        let Some(onclick) = onclick else { continue };
+
+        let Some(id_cap) = re_athlete_id.captures_iter(onclick).next() else { continue };
+        let Ok(athlete_id) = id_cap[1].parse::<u32>() else { continue };
 
         res.push(AthleteListElement {
             id: athlete_id,
             name: name.to_string(),
             club_name: captures[2].to_string(),
-            age: captures[1].parse()?,
+            age: captures[1].parse().unwrap_or(0),
         });
     }
 

--- a/atletiek-nu-api/src/models/athlete_list.rs
+++ b/atletiek-nu-api/src/models/athlete_list.rs
@@ -1,3 +1,4 @@
+use log::trace;
 use regex::Regex;
 use scraper::{Html, Selector};
 use serde::{Deserialize, Serialize};
@@ -32,11 +33,17 @@ pub fn parse(html: Html) -> anyhow::Result<AthleteList> {
             .filter(|v| !v.is_empty())
             .collect();
 
-        if texts.len() < 2 { continue; }
+        if texts.len() < 2 {
+            trace!("skipping athlete row: expected >=2 text nodes, got {} ({:?})", texts.len(), texts);
+            continue;
+        }
         let name = texts[0].replace("  ", " ");
         let age_and_club = texts[1];
 
-        let Some(captures) = re_age_and_club.captures_iter(&age_and_club).next() else { continue };
+        let Some(captures) = re_age_and_club.captures_iter(&age_and_club).next() else {
+            trace!("skipping athlete row: age/club regex did not match: {:?}", age_and_club);
+            continue;
+        };
 
         let onclick = i
             .parent()
@@ -44,10 +51,19 @@ pub fn parse(html: Html) -> anyhow::Result<AthleteList> {
             .and_then(|p| p.value().as_element())
             .and_then(|e| e.attr("onclick"));
 
-        let Some(onclick) = onclick else { continue };
+        let Some(onclick) = onclick else {
+            trace!("skipping athlete row: missing onclick on grandparent element (name={:?})", name);
+            continue;
+        };
 
-        let Some(id_cap) = re_athlete_id.captures_iter(onclick).next() else { continue };
-        let Ok(athlete_id) = id_cap[1].parse::<u32>() else { continue };
+        let Some(id_cap) = re_athlete_id.captures_iter(onclick).next() else {
+            trace!("skipping athlete row: athlete_id regex did not match onclick: {:?}", onclick);
+            continue;
+        };
+        let Ok(athlete_id) = id_cap[1].parse::<u32>() else {
+            trace!("skipping athlete row: could not parse athlete_id as u32: {:?}", &id_cap[1]);
+            continue;
+        };
 
         res.push(AthleteListElement {
             id: athlete_id,

--- a/atletiek-nu-api/src/models/athlete_profile.rs
+++ b/atletiek-nu-api/src/models/athlete_profile.rs
@@ -74,9 +74,16 @@ pub fn parse(html: Html) -> anyhow::Result<AthleteProfile> {
     let re_div_spec = Regex::new(REGEX_DIV_SPECIFICATION).unwrap();
 
     let mut name = String::new();
-    let mut page_title_texts = html.select(&page_title_selector).next().unwrap().text();
+    let mut page_title_texts = html
+        .select(&page_title_selector)
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("missing div.pageTitle on profile page"))?
+        .text();
     while name.is_empty() {
-        name = page_title_texts.next().unwrap().trim().replace("  ", " ");
+        let next = page_title_texts
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("empty text in div.pageTitle"))?;
+        name = next.trim().replace("  ", " ");
     }
 
     let competitions = competition_registrations_list::parse(html.root_element())?;
@@ -97,13 +104,16 @@ pub fn parse(html: Html) -> anyhow::Result<AthleteProfile> {
             attribute: None,
         };
 
-        item.not_important = row.value().attr("class").unwrap().contains("notThatImportant");
+        item.not_important = row.value().attr("class")
+            .map(|c| c.contains("notThatImportant"))
+            .unwrap_or(false);
 
         item.event = {
-            let element = cells.next().unwrap();
+            let element = cells.next()
+                .ok_or_else(|| anyhow::anyhow!("missing event cell in PB row"))?;
 
             for i in element.select(&subtext_span_selector) {
-                let text = i.text().next().unwrap().trim().to_string();
+                let text = i.text().next().unwrap_or_default().trim().to_string();
                 if text.is_empty() {
                     continue;
                 }
@@ -125,12 +135,15 @@ pub fn parse(html: Html) -> anyhow::Result<AthleteProfile> {
                 }
             }
 
-            element.text().next().unwrap().trim().to_string()
+            element.text().next().unwrap_or_default().trim().to_string()
         };
 
         {
-            let element = cells.next().unwrap();
-            let performance_text = element.text().next().unwrap().trim();
+            let element = cells.next()
+                .ok_or_else(|| anyhow::anyhow!("missing performance cell in PB row"))?;
+            let performance_text = element.text().next()
+                .ok_or_else(|| anyhow::anyhow!("empty performance cell text"))?
+                .trim();
             item.display_performance = performance_text.to_string();
 
             // prepend 0: for a little bit of regex hacking so the first group always captures
@@ -139,11 +152,12 @@ pub fn parse(html: Html) -> anyhow::Result<AthleteProfile> {
             padded_performance_text.push_str(performance_text);
             padded_performance_text.push_str(",0");
             trace!("Got performance text {} -> {}", performance_text, padded_performance_text);
-            let captures = re_performance.captures_iter(&padded_performance_text).next().unwrap();
+            let captures = re_performance.captures_iter(&padded_performance_text).next()
+                .ok_or_else(|| anyhow::anyhow!("performance regex did not match: {}", padded_performance_text))?;
 
-            let minutes = captures[1].parse::<u32>().unwrap();
-            let seconds = captures[2].parse::<u32>().unwrap();
-            let milliseconds = captures[3].parse::<u32>().unwrap();
+            let minutes = captures[1].parse::<u32>()?;
+            let seconds = captures[2].parse::<u32>()?;
+            let milliseconds = captures[3].parse::<u32>()?;
             let ms_accuracy = captures[3].len();
 
             // contains 'h' if hand measured
@@ -153,26 +167,30 @@ pub fn parse(html: Html) -> anyhow::Result<AthleteProfile> {
             trace!("Parsed to {:.2} hand measured {}", item.performance, item.hand_measured);
 
             if let Some(Some(span)) = element.select(&subtext_span_selector).next().map(|v| v.select(&span_selector).next()) {
-                // wind speed
-                let text = span.text().next().unwrap();
+                let text = span.text().next().unwrap_or_default();
                 item.wind_speed = crate::components::wind_speed::parse(text);
                 trace!("Got wind speed text {} -> {:?}", text, item.wind_speed);
             }
         }
 
         {
-            let element = cells.next().unwrap();
-            let span = element.select(&sort_span_selector).next().unwrap();
-            let data_text = span.value().attr("data").unwrap().to_string();
+            let element = cells.next()
+                .ok_or_else(|| anyhow::anyhow!("missing date/location cell in PB row"))?;
+            let span = element.select(&sort_span_selector).next()
+                .ok_or_else(|| anyhow::anyhow!("missing sortData span in PB date cell"))?;
+            let data_text = span.value().attr("data")
+                .ok_or_else(|| anyhow::anyhow!("missing data attribute on sortData span"))?
+                .to_string();
 
             trace!("Got pb sort text {}", data_text);
 
-            let captures = re_pb_data.captures_iter(&data_text).next().unwrap();
+            let captures = re_pb_data.captures_iter(&data_text).next()
+                .ok_or_else(|| anyhow::anyhow!("PB sort data regex did not match: {}", data_text))?;
             item.date = NaiveDate::from_ymd_opt(
-                captures[1].parse().unwrap(),
-                captures[2].parse().unwrap(),
-                captures[3].parse().unwrap()
-            ).unwrap();
+                captures[1].parse()?,
+                captures[2].parse()?,
+                captures[3].parse()?
+            ).ok_or_else(|| anyhow::anyhow!("invalid date in PB sort data"))?;
             item.location = captures[4].to_string();
             item.country = captures[5].to_string();
         }
@@ -186,12 +204,12 @@ pub fn parse(html: Html) -> anyhow::Result<AthleteProfile> {
 
     for graph in html.select(&graph_selector) {
         for div in graph.select(&spec_div_selector) {
-            let target = div.value().attr("data-target").unwrap();
+            let Some(target) = div.value().attr("data-target") else { continue };
             let (event_id, spec) = {
-                let captures = re_div_spec.captures_iter(target).next().unwrap();
+                let Some(captures) = re_div_spec.captures_iter(target).next() else { continue };
                 (captures[1].to_string(), captures[2].to_string())
             };
-            let text = div.text().next().unwrap();
+            let Some(text) = div.text().next() else { continue };
             let attr = match text {
                 "Everything" => EventAttribute::All,
                 _ => parse_attribute(text).unwrap(),
@@ -211,23 +229,26 @@ pub fn parse(html: Html) -> anyhow::Result<AthleteProfile> {
             let text = html.trim().replace("\t", "").replace("\n", "");
 
             let (event_name, point_count) = {
-                let captures = re_graph_info.captures_iter(&text).next().unwrap();
-                (captures[1].to_string(), captures[2].parse::<usize>().unwrap())
+                let Some(captures) = re_graph_info.captures_iter(&text).next() else { continue };
+                (captures[1].to_string(), captures[2].parse::<usize>().unwrap_or(0))
             };
-            let event_id = re_graph_event_id.captures_iter(&text).next().unwrap()[1].to_string();
-            let specification = re_graph_spec.captures_iter(&text).next().unwrap()[1].to_string();
+            let Some(event_id_cap) = re_graph_event_id.captures_iter(&text).next() else { continue };
+            let event_id = event_id_cap[1].to_string();
+            let Some(spec_cap) = re_graph_spec.captures_iter(&text).next() else { continue };
+            let specification = spec_cap[1].to_string();
             trace!("Found graph for {}, {} points (event id {}, spec {})", event_name, point_count, event_id, specification);
 
             let mut points = Vec::new();
 
             for point in re_graph_points.captures_iter(&text) {
                 trace!("Point capture {} {} {} {}", point[1].to_string(), point[2].to_string(), point[3].to_string(), point[4].to_string());
-                let date = NaiveDate::from_ymd_opt(
-                    point[1].parse().unwrap(),
-                    point[2].parse::<u32>().unwrap() + 1, // in javascript months are 0-based
-                    point[3].parse().unwrap()
-                ).unwrap();
-                let performance = point[4].parse().unwrap();
+                let (Ok(year), Ok(month), Ok(day), Ok(performance)) = (
+                    point[1].parse::<i32>(),
+                    point[2].parse::<u32>(),
+                    point[3].parse::<u32>(),
+                    point[4].parse::<f32>(),
+                ) else { continue };
+                let Some(date) = NaiveDate::from_ymd_opt(year, month + 1, day) else { continue }; // JS months are 0-based
 
                 points.push((date, performance));
             }
@@ -237,10 +258,10 @@ pub fn parse(html: Html) -> anyhow::Result<AthleteProfile> {
                     if specification == event_id {
                         EventAttribute::All
                     } else {
-                        specs.get(&specification).unwrap().to_owned()
+                        specs.get(&specification).cloned().unwrap_or(EventAttribute::All)
                     }
                 },
-                event_id: event_id.parse().unwrap(),
+                event_id: event_id.parse().unwrap_or(0),
                 event: event_name,
                 points
             })
@@ -255,8 +276,8 @@ pub fn parse(html: Html) -> anyhow::Result<AthleteProfile> {
 fn parse_attribute(text: &str) -> Option<EventAttribute> {
     let re_attribute = Regex::new(REGEX_ATTRIBUTE).unwrap();
 
-    let captures = re_attribute.captures_iter(&text).next().unwrap();
-    let value: f32 = captures[1].parse().unwrap();
+    let captures = re_attribute.captures_iter(&text).next()?;
+    let value: f32 = captures[1].parse().ok()?;
     match captures[2].to_string().as_str() {
         "cm" => Some(EventAttribute::Height(value / 100.0)),
         "gr" => Some(EventAttribute::Weight(value / 1000.0)),

--- a/atletiek-nu-api/src/models/athlete_profile.rs
+++ b/atletiek-nu-api/src/models/athlete_profile.rs
@@ -204,12 +204,21 @@ pub fn parse(html: Html) -> anyhow::Result<AthleteProfile> {
 
     for graph in html.select(&graph_selector) {
         for div in graph.select(&spec_div_selector) {
-            let Some(target) = div.value().attr("data-target") else { continue };
+            let Some(target) = div.value().attr("data-target") else {
+                trace!("skipping spec div: missing data-target attribute");
+                continue;
+            };
             let (event_id, spec) = {
-                let Some(captures) = re_div_spec.captures_iter(target).next() else { continue };
+                let Some(captures) = re_div_spec.captures_iter(target).next() else {
+                    trace!("skipping spec div: div_spec regex did not match: {:?}", target);
+                    continue;
+                };
                 (captures[1].to_string(), captures[2].to_string())
             };
-            let Some(text) = div.text().next() else { continue };
+            let Some(text) = div.text().next() else {
+                trace!("skipping spec div: no text content (event_id={}, spec={})", event_id, spec);
+                continue;
+            };
             let attr = match text {
                 "Everything" => EventAttribute::All,
                 _ => parse_attribute(text).unwrap(),
@@ -229,12 +238,21 @@ pub fn parse(html: Html) -> anyhow::Result<AthleteProfile> {
             let text = html.trim().replace("\t", "").replace("\n", "");
 
             let (event_name, point_count) = {
-                let Some(captures) = re_graph_info.captures_iter(&text).next() else { continue };
+                let Some(captures) = re_graph_info.captures_iter(&text).next() else {
+                    trace!("skipping graph script: graph_info regex did not match");
+                    continue;
+                };
                 (captures[1].to_string(), captures[2].parse::<usize>().unwrap_or(0))
             };
-            let Some(event_id_cap) = re_graph_event_id.captures_iter(&text).next() else { continue };
+            let Some(event_id_cap) = re_graph_event_id.captures_iter(&text).next() else {
+                trace!("skipping graph script: graph_event_id regex did not match (event={})", event_name);
+                continue;
+            };
             let event_id = event_id_cap[1].to_string();
-            let Some(spec_cap) = re_graph_spec.captures_iter(&text).next() else { continue };
+            let Some(spec_cap) = re_graph_spec.captures_iter(&text).next() else {
+                trace!("skipping graph script: graph_spec regex did not match (event={}, event_id={})", event_name, event_id);
+                continue;
+            };
             let specification = spec_cap[1].to_string();
             trace!("Found graph for {}, {} points (event id {}, spec {})", event_name, point_count, event_id, specification);
 
@@ -247,8 +265,15 @@ pub fn parse(html: Html) -> anyhow::Result<AthleteProfile> {
                     point[2].parse::<u32>(),
                     point[3].parse::<u32>(),
                     point[4].parse::<f32>(),
-                ) else { continue };
-                let Some(date) = NaiveDate::from_ymd_opt(year, month + 1, day) else { continue }; // JS months are 0-based
+                ) else {
+                    trace!("skipping graph point: failed to parse one of year/month/day/performance ({:?},{:?},{:?},{:?})",
+                        &point[1], &point[2], &point[3], &point[4]);
+                    continue;
+                };
+                let Some(date) = NaiveDate::from_ymd_opt(year, month + 1, day) else {
+                    trace!("skipping graph point: invalid date y={} m={} d={}", year, month + 1, day);
+                    continue;
+                }; // JS months are 0-based
 
                 points.push((date, performance));
             }

--- a/atletiek-nu-api/src/models/competition_registrations_list.rs
+++ b/atletiek-nu-api/src/models/competition_registrations_list.rs
@@ -39,37 +39,42 @@ pub fn parse(element: ElementRef) -> anyhow::Result<CompetitionRegistrationList>
 
     if let Some(competitions_table) = element.select(&competition_list_selector).next() {
         for row in competitions_table.select(&competition_list_row_selector) {
-            let link = row.select(&competition_list_link_selector).next().unwrap();
-            //dbg!(row.html());
-            let date: String = row.select(&competition_list_sortdata_selector).next()
-                .unwrap()
-                .value().attr("data").unwrap()
-                // we want to drop the location from the string so keep only digits
-                .chars().filter(|v| v.is_ascii_digit()).collect();
+            let Some(link) = row.select(&competition_list_link_selector).next() else { continue };
 
-            let date = NaiveDate::parse_from_str(&date, "%Y%m%d").unwrap();
-
-            let text = link.text().filter(|v| {
-                !v.trim().is_empty()
-            }).next().unwrap().trim().to_string();
-            let participant_id = if let Some(v) = link.select(&a_selector).next() {
-                // if there is a child, it will be <a> with a link to the competition
-               let s = v.value().attr("href").unwrap();
-                re_participant.captures_iter(s).next().unwrap()[1].parse().unwrap()
-            } else { 0 };
-
-            let location_element = row.select(&competition_list_location_selector).next().unwrap();
-            let place = location_element.text().next().unwrap();
-
-            let (flag_img_url, country, continent) = if let Some(location_img) = location_element.select(&img_selector).next() {
-                let flag_img_src = location_img.value().attr("src").unwrap();
-
-                let captures = re_location.captures_iter(location_img.value().attr("title").unwrap()).next().unwrap();
-                (flag_img_src.to_string(), captures[1].trim().to_string(), captures[2].trim().to_string())
-            } else {
-                ("".to_string(), "".to_string(), "".to_string())
+            let date_str: String = match row.select(&competition_list_sortdata_selector).next()
+                .and_then(|el| el.value().attr("data")) {
+                Some(d) => d.chars().filter(|v| v.is_ascii_digit()).collect(),
+                None => continue,
             };
 
+            let Ok(date) = NaiveDate::parse_from_str(&date_str, "%Y%m%d") else { continue };
+
+            let text = match link.text().filter(|v| !v.trim().is_empty()).next() {
+                Some(t) => t.trim().to_string(),
+                None => continue,
+            };
+            let participant_id = if let Some(v) = link.select(&a_selector).next() {
+                v.value().attr("href")
+                    .and_then(|s| re_participant.captures_iter(s).next())
+                    .and_then(|c| c[1].parse().ok())
+                    .unwrap_or(0)
+            } else { 0 };
+
+            let Some(location_element) = row.select(&competition_list_location_selector).next() else { continue };
+            let place = location_element.text().next().unwrap_or_default();
+
+            let (flag_img_url, country, continent) = if let Some(location_img) = location_element.select(&img_selector).next() {
+                let flag_img_src = location_img.value().attr("src").unwrap_or_default();
+
+                let title = location_img.value().attr("title").unwrap_or_default();
+                if let Some(captures) = re_location.captures_iter(title).next() {
+                    (flag_img_src.to_string(), captures[1].trim().to_string(), captures[2].trim().to_string())
+                } else {
+                    (flag_img_src.to_string(), String::new(), String::new())
+                }
+            } else {
+                (String::new(), String::new(), String::new())
+            };
 
             participated_in.push(CompetitionRegistration {
                 participant_id,

--- a/atletiek-nu-api/src/models/competition_registrations_list.rs
+++ b/atletiek-nu-api/src/models/competition_registrations_list.rs
@@ -1,4 +1,5 @@
 use chrono::NaiveDate;
+use log::trace;
 use regex::Regex;
 use scraper::{ElementRef, Selector};
 use serde::{Deserialize, Serialize};
@@ -39,19 +40,31 @@ pub fn parse(element: ElementRef) -> anyhow::Result<CompetitionRegistrationList>
 
     if let Some(competitions_table) = element.select(&competition_list_selector).next() {
         for row in competitions_table.select(&competition_list_row_selector) {
-            let Some(link) = row.select(&competition_list_link_selector).next() else { continue };
+            let Some(link) = row.select(&competition_list_link_selector).next() else {
+                trace!("skipping registration row: no link cell (td) found");
+                continue;
+            };
 
             let date_str: String = match row.select(&competition_list_sortdata_selector).next()
                 .and_then(|el| el.value().attr("data")) {
                 Some(d) => d.chars().filter(|v| v.is_ascii_digit()).collect(),
-                None => continue,
+                None => {
+                    trace!("skipping registration row: missing sortData span or data attribute");
+                    continue;
+                }
             };
 
-            let Ok(date) = NaiveDate::parse_from_str(&date_str, "%Y%m%d") else { continue };
+            let Ok(date) = NaiveDate::parse_from_str(&date_str, "%Y%m%d") else {
+                trace!("skipping registration row: could not parse date from {:?}", date_str);
+                continue;
+            };
 
             let text = match link.text().filter(|v| !v.trim().is_empty()).next() {
                 Some(t) => t.trim().to_string(),
-                None => continue,
+                None => {
+                    trace!("skipping registration row: link cell has no non-empty text");
+                    continue;
+                }
             };
             let participant_id = if let Some(v) = link.select(&a_selector).next() {
                 v.value().attr("href")
@@ -60,7 +73,10 @@ pub fn parse(element: ElementRef) -> anyhow::Result<CompetitionRegistrationList>
                     .unwrap_or(0)
             } else { 0 };
 
-            let Some(location_element) = row.select(&competition_list_location_selector).next() else { continue };
+            let Some(location_element) = row.select(&competition_list_location_selector).next() else {
+                trace!("skipping registration row: missing location element (name={:?})", text);
+                continue;
+            };
             let place = location_element.text().next().unwrap_or_default();
 
             let (flag_img_url, country, continent) = if let Some(location_img) = location_element.select(&img_selector).next() {


### PR DESCRIPTION
Follow-up to #16 — turns the cryptic Cloudflare 1101 errors into actionable HTTP statuses.

As discussed in the issue thread, the root cause (athletics.app serving anti-bot / stripped HTML when rate-limited) is external and not really fixable from here. But the **user-facing symptom** is — and the parser had a lot of `.unwrap()` calls that would panic the worker on any unexpected input.

## What this PR does

### 1. Detect the anti-bot page early (`src/lib.rs`)

After `let text = res.text().await?;` in `send_request`, check for the Turnstile interstitial markers and bail with a typed error before the parser even runs:

```rust
if text.contains("challenges.cloudflare.com/turnstile")
    || text.contains("Checking your webbrowser")
    || text.contains("Checking your browser")
{
    anyhow::bail!("athletics.app served an anti-bot challenge page (rate-limited?)");
}
```

### 2. Replace panicking unwraps in parsers

Three model files were panicking on stripped/malformed HTML:

- **`athlete_profile.rs`** — every `.unwrap()` on parser inputs (page title selector, PB row cells, regex captures, graph script regexes, etc.) replaced with either `ok_or_else(|| anyhow!(...))?` (when the field is required) or `let Some(x) = ... else { continue }` (when missing fields should just skip the row).
- **`athlete_list.rs`** — same treatment for the `.parent().unwrap().parent().unwrap()` chain and the regex captures.
- **`competition_registrations_list.rs`** — same for the date/location cell unwraps.

Selector compilation (`Selector::parse("...").unwrap()`) and regex compilation are kept as `unwrap()` since those are compile-time constants — if they fail, that's a bug in the code, not in the data.

### 3. Map errors in the worker (`api-cfworker/src/lib.rs`)

A helper `map_scraper_error(msg)` returns:
- **HTTP 503 + `Retry-After: 300`** if the error contains `"anti-bot challenge"` (clear signal to the client to back off)
- **HTTP 500 + `Scraping error: {msg}`** otherwise (so the client sees what actually broke — selector missing? regex didn't match? — instead of a generic 1101)

All six endpoint handlers were updated to use it.

## Testing

Deployed this branch as a self-hosted worker and ran smoke tests against the live site:

| Endpoint | Before | After |
|---|---|---|
| `/competitions/results/2065498` | 200 ✓ | 200 ✓ |
| `/athletes/profile/1146851` | 1101 (panic) | 200 with full data ✓ |
| `/athletes/search/Borlee` | 1101 (panic) | 200 with results ✓ |
| `/athletes/profile/<bad-id>` | 1101 (panic) | 500 with descriptive parser error |

No behavioural change for the happy path — only error handling.

## Notes

- The Cargo.lock / wrangler.toml from my deploy are intentionally **not** in this PR — those are specific to my Cloudflare account.
- I left the pre-existing `console_error_panic_hook` in place; with these fixes it should rarely trigger, but it's a useful safety net.
- If you'd like, I can split this into separate commits (anti-bot detection / parser fixes / worker mapping) — just say the word.

Thanks again for maintaining this!
