### PR TITLE
Add mobile endpoint support to bypass Cloudflare Turnstile

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -1,0 +1,34 @@
+name: Deploy Cloudflare Worker
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'api-cfworker/**'
+      - 'atletiek-nu-api/**'
+
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust + wasm32 target
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Install worker-build
+        run: cargo install worker-build
+
+      - name: Build and deploy
+        working-directory: api-cfworker
+        run: npx wrangler deploy --config wrangler.matlof39.toml
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/README.md
+++ b/README.md
@@ -1,19 +1,183 @@
 # atletiek-nu-api
-A work-in-progress attempt at scraping the [athletics.app](https://athletics.app) (previously [atletiek.nu](https://atletiek.nu) but they changed their domain) website for data. Kinda works but far from complete.
 
-What it can do as of now:
-- Search for competitions
-- List registrations for a competition (including registration status such as accepted, rejected, etc.)
-- List results for an athlete for a given competition
-- Search athletes and list their profile with PB's, a list of all preformances in a specific category, and all competitions they participated in
-- List competitions for a given time period
+A Rust library and HTTP API for scraping [athletics.app](https://athletics.app) (previously [atletiek.nu](https://atletiek.nu)) data.
 
-**Note:** The scraper still has many bugs and will not be able to scrape all pages. Please create an issue if you encounter a bug.
+## Cloudflare Turnstile
 
-# HTTP API
-An api is hosted at `https://atnapi.juandomingo.net` using cloudflare workers.
-[Documentation](./api-cfworker/README.md)
+The athletics.app website now uses **Cloudflare Turnstile** anti-bot protection on most web-facing pages. This blocks the traditional web scraping endpoints. The **mobile endpoints** (`athleteapp.php`) are **not affected** and should be preferred.
 
-# Local HTTP API
-There is also a HTTP api availible for download from the releases on [github.com](https://github.com/zeskeertwee/atletiek-nu-api/releases)
-Or, alternatively, you can compile the HTTP api from scratch after cloning the repository like so: `cargo build --release --bin api`
+| Endpoint type | Blocked by Cloudflare | Recommendation |
+|---------------|----------------------|----------------|
+| Web (`/atleet/`, `/wedstrijd/`, `feeder.php`) | Yes | Avoid — will return challenge pages |
+| Mobile (`athleteapp.php`) | No | Preferred — reliable and richer data |
+
+## API endpoints
+
+### Mobile endpoints (recommended)
+
+These endpoints use the athletics.app mobile API and are **not blocked by Cloudflare**.
+
+---
+
+#### `GET /mobile/athletes/profile/<id>`
+
+Returns an athlete's personal bests with full per-event performance history.
+
+**Parameters:**
+- `id` — athlete ID (`ranglijst_score_koppel_id`)
+
+**Response includes:**
+- Personal bests with event name, performance, wind speed, hand-measured flag, indoor flag, location, country code, date
+- Per-event performance history with wind speed, location, country code, delta/progression
+
+**Example response:**
+```json
+{
+  "name": "John Doe",
+  "personal_bests": [
+    {
+      "event": "100m",
+      "performance": "10.85",
+      "performance_value": 10.85,
+      "wind_speed": 1.2,
+      "hand_measured": false,
+      "location": "Amsterdam",
+      "country_code": "nl",
+      "date": "15 Jun 2024",
+      "not_important": false,
+      "indoor": false,
+      "history": [
+        {
+          "performance": "10.85",
+          "performance_value": 10.85,
+          "wind_speed": 1.2,
+          "hand_measured": false,
+          "location": "Amsterdam",
+          "country_code": "nl",
+          "date": "15 Jun 2024",
+          "delta": "-0.03"
+        }
+      ]
+    }
+  ]
+}
+```
+
+---
+
+#### `GET /mobile/competitions/search?country=<country>&start=<date>&end=<date>&query=<text>`
+
+Search for competitions using the mobile API.
+
+**Parameters:**
+- `country` — ISO2 country code (e.g. `NL`, `BE`, `FR`)
+- `start` — start date (`YYYY-MM-DD`)
+- `end` — end date (`YYYY-MM-DD`)
+- `query` — *(optional)* search text
+
+**Response includes:**
+- Competition ID, name, location, date display
+- Number of registrations
+- Club-only flag, World Athletics recognized flag, cancelled flag
+
+---
+
+### Web endpoints (legacy)
+
+These endpoints scrape the athletics.app web pages directly. **Most are now blocked by Cloudflare Turnstile** and will fail with an anti-bot challenge error.
+
+---
+
+#### `GET /competitions/search?start=<date>&end=<date>&query=<text>`
+
+> ⚠️ **Blocked by Cloudflare** — use `/mobile/competitions/search` instead.
+
+Search for competitions in a given time period.
+
+**Parameters:**
+- `start` — start date (`YYYY-MM-DD`)
+- `end` — end date (`YYYY-MM-DD`)
+- `query` — *(optional)* search text
+
+---
+
+#### `GET /competitions/registrations/<id>`
+
+> ⚠️ **Blocked by Cloudflare** — no mobile alternative with equivalent data.
+
+List all registrations for a competition.
+
+**Parameters:**
+- `id` — competition ID
+
+---
+
+#### `GET /competitions/results/<id>`
+
+> ⚠️ **Blocked by Cloudflare** — no mobile alternative.
+
+List all performances for a participant ID, alongside competitions and timetable.
+
+**Parameters:**
+- `id` — participant ID
+
+---
+
+#### `GET /athletes/search/<query>`
+
+Search for athletes by name. Uses the mobile endpoint internally, so this still works.
+
+**Parameters:**
+- `query` — search string
+
+---
+
+#### `GET /athletes/profile/<id>`
+
+> ⚠️ **Blocked by Cloudflare** — use `/mobile/athletes/profile/<id>` instead (with richer data).
+
+Returns the athlete's profile with personal bests.
+
+**Parameters:**
+- `id` — athlete ID
+
+---
+
+## Data comparison: Web vs Mobile
+
+| Data field | Web profile | Mobile profile |
+|------------|:-----------:|:--------------:|
+| Personal bests | ✅ | ✅ |
+| Wind speed (PR) | ❌ | ✅ |
+| Hand-measured flag | ❌ | ✅ |
+| Indoor flag | ❌ | ✅ |
+| Country code | ❌ | ✅ |
+| Performance history | ⚠️ Float + date only | ✅ Full details |
+| History: wind speed | ❌ | ✅ |
+| History: location | ❌ | ✅ |
+| History: country | ❌ | ✅ |
+| History: progression delta | ❌ | ✅ |
+
+## Building
+
+### Library
+
+```bash
+cargo build --release -p atletiek_nu_api
+```
+
+### HTTP API server
+
+```bash
+cargo build --release --bin api
+```
+
+A pre-built binary is also available from [GitHub Releases](https://github.com/zeskeertwee/atletiek-nu-api/releases).
+
+## Cloudflare worker API
+
+A hosted version is available at `https://atnapi.juandomingo.net` using Cloudflare Workers. See [api-cfworker/README.md](./api-cfworker/README.md) for details.
+
+## Note
+
+The scraper still has bugs and may not handle all pages. Please create an issue if you encounter a problem.

--- a/api-cfworker/Cargo.lock
+++ b/api-cfworker/Cargo.lock
@@ -816,13 +816,12 @@ checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "js-sys"
-version = "0.3.98"
+version = "0.3.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+checksum = "f2025f20d7a4fa7785846e7b63d10a76d3f1cee98ee5cb79ea59703f95e42162"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -1918,9 +1917,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.121"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+checksum = "a254a4b10c19a76f09a27640e7ffbf9bc30bf67e16a3bf28aaefa4920fe81563"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1931,9 +1930,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.71"
+version = "0.4.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
+checksum = "54568702fabf5d4849ce2b90fadfa64168a097eaf4b351ce9df8b687a0086aaf"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1941,9 +1940,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.121"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+checksum = "24a40fc75b0ec6f3746ceb10d36f53a93dcd68a93b11b6445983945d79eba0dc"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1951,9 +1950,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.121"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+checksum = "908f34bd9b9ce3d4caf07b72dfab63d61504d156856c6bd3cd87fa350cf3985b"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1964,9 +1963,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.121"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+checksum = "7acbf7616c27b194bbb550bf77ed0c2c3e5b7fd1260a93082b95fb7f47959b92"
 dependencies = [
  "unicode-ident",
 ]
@@ -1986,9 +1985,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.98"
+version = "0.3.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
+checksum = "6e0871acf327f283dc6da28a1696cdc64fb355ba9f935d052021fa77f35cce69"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2224,6 +2223,7 @@ dependencies = [
  "getrandom 0.2.15",
  "git-version",
  "urlencoding",
+ "wasm-bindgen",
  "worker",
 ]
 

--- a/api-cfworker/Cargo.toml
+++ b/api-cfworker/Cargo.toml
@@ -15,6 +15,7 @@ worker = { version = "0.8.3", features = ["d1"] }
 getrandom = { version = "0.2.15", features = ["js"] }
 urlencoding = "2.1.3"
 console_error_panic_hook = "0.1.7"
+wasm-bindgen = "0.2.123"
 git-version = "0.3.9"
 
 [dependencies.atletiek_nu_api]

--- a/api-cfworker/src/lib.rs
+++ b/api-cfworker/src/lib.rs
@@ -106,6 +106,24 @@ async fn main(req: Request, env: Env, ctx: Context) -> Result<Response> {
                 Response::error("Missing ID", 400)
             }
         })
+        .get_async("/mobile/athletes/profile/:id", |_req, ctx| async move {
+            if let Some(id) = ctx.param("id") {
+                if let Ok(id) = id.parse() {
+                    let result = atletiek_nu_api::get_athlete_profile_mobile(id).await;
+                    match result {
+                        Ok(r) => Response::from_json(&r),
+                        Err(e) => {
+                            console_error!("Error fetching mobile profile: {}", e);
+                            Response::error("Internal error", 500)
+                        }
+                    }
+                } else {
+                    Response::error("Unable to parse ID", 400)
+                }
+            } else {
+                Response::error("Missing ID", 400)
+            }
+        })
         .get_async("/v1/competitions/registrations/:id", |_req, ctx| async move {
             if let Some(id) = ctx.param("id") {
                 if let Ok(id) = id.parse::<u32>() {

--- a/api-cfworker/src/lib.rs
+++ b/api-cfworker/src/lib.rs
@@ -135,6 +135,42 @@ async fn main(req: Request, env: Env, ctx: Context) -> Result<Response> {
                 Response::error("Missing ID", 400)
             }
         })
+        .get_async("/mobile/competitions/detail/:id", |_req, ctx| async move {
+            if let Some(id) = ctx.param("id") {
+                if let Ok(id) = id.parse() {
+                    match atletiek_nu_api::get_competition_detail_mobile(id).await {
+                        Ok(r) => Response::from_json(&r),
+                        Err(e) => {
+                            let msg = e.to_string();
+                            console_error!("Error fetching competition detail {}: {}", id, msg);
+                            map_scraper_error(&msg)
+                        }
+                    }
+                } else {
+                    Response::error("Unable to parse ID", 400)
+                }
+            } else {
+                Response::error("Missing ID", 400)
+            }
+        })
+        .get_async("/mobile/competitions/program/:id", |_req, ctx| async move {
+            if let Some(id) = ctx.param("id") {
+                if let Ok(id) = id.parse() {
+                    match atletiek_nu_api::get_competition_program_mobile(id).await {
+                        Ok(r) => Response::from_json(&r),
+                        Err(e) => {
+                            let msg = e.to_string();
+                            console_error!("Error fetching competition program {}: {}", id, msg);
+                            map_scraper_error(&msg)
+                        }
+                    }
+                } else {
+                    Response::error("Unable to parse ID", 400)
+                }
+            } else {
+                Response::error("Missing ID", 400)
+            }
+        })
         .get_async("/mobile/competitions/search", |req, _ctx| async move {
             if let Ok(url) = req.url() {
                 let pairs: HashMap<String, String> = url

--- a/api-cfworker/src/lib.rs
+++ b/api-cfworker/src/lib.rs
@@ -124,6 +124,53 @@ async fn main(req: Request, env: Env, ctx: Context) -> Result<Response> {
                 Response::error("Missing ID", 400)
             }
         })
+        .get_async("/mobile/competitions/search", |req, _ctx| async move {
+            if let Ok(url) = req.url() {
+                let pairs: HashMap<String, String> = url
+                    .query_pairs()
+                    .into_iter()
+                    .map(|v| (v.0.to_string(), v.1.to_string()))
+                    .fold(HashMap::new(), |mut acc, v| { acc.insert(v.0, v.1); acc });
+
+                let country = pairs.get("country").map(|v| v.as_str()).unwrap_or("NL");
+
+                let start_date = if let Some(v) = pairs.get("start") {
+                    if let Ok(v) = parse_naive_date(v) {
+                        v
+                    } else {
+                        return Response::error("Malformed start date", 400);
+                    }
+                } else {
+                    return Response::error("Missing start date", 400);
+                };
+
+                let end_date = if let Some(v) = pairs.get("end") {
+                    if let Ok(v) = parse_naive_date(v) {
+                        v
+                    } else {
+                        return Response::error("Malformed end date", 400);
+                    }
+                } else {
+                    return Response::error("Missing end date", 400);
+                };
+
+                if end_date < start_date {
+                    return Response::error("End date is before start date", 400);
+                }
+
+                let query = pairs.get("query").map(|v| v.as_str()).unwrap_or("");
+
+                match atletiek_nu_api::search_competitions_mobile(country, start_date, end_date, query).await {
+                    Ok(r) => Response::from_json(&r),
+                    Err(e) => {
+                        console_error!("Error searching competitions (mobile): {}", e);
+                        Response::error("Internal error", 500)
+                    }
+                }
+            } else {
+                Response::error("Internal error", 500)
+            }
+        })
         .get_async("/v1/competitions/registrations/:id", |_req, ctx| async move {
             if let Some(id) = ctx.param("id") {
                 if let Ok(id) = id.parse::<u32>() {

--- a/api-cfworker/wrangler.matlof39.toml
+++ b/api-cfworker/wrangler.matlof39.toml
@@ -1,0 +1,19 @@
+name = "atletiek-nu-api"
+main = "build/worker/shim.mjs"
+compatibility_date = "2024-09-23"
+account_id = "fc75876132ba8bfcc175f471af6aa2ce"
+send_metrics = false
+
+# Deploy to workers.dev (no custom domain needed)
+workers_dev = true
+
+[build]
+command = "cargo install -q worker-build && worker-build --release"
+
+[observability]
+enabled = true
+
+[observability.logs]
+enabled = true
+invocation_logs = true
+head_sampling_rate = 1

--- a/api/src/cache/mod.rs
+++ b/api/src/cache/mod.rs
@@ -49,6 +49,12 @@ pub enum CachedRequest {
         end: NaiveDate,
         query: String,
     },
+    GetCompetitionDetailMobile {
+        id: u32,
+    },
+    GetCompetitionProgramMobile {
+        id: u32,
+    },
 }
 
 #[derive(Serialize)]
@@ -106,6 +112,14 @@ impl CachedRequest {
         Self::SearchCompetitionsMobile { country, start, end, query }
     }
 
+    pub fn new_get_competition_detail_mobile(id: u32) -> Self {
+        Self::GetCompetitionDetailMobile { id }
+    }
+
+    pub fn new_get_competition_program_mobile(id: u32) -> Self {
+        Self::GetCompetitionProgramMobile { id }
+    }
+
     fn cache_duration(&self) -> Duration {
         match self {
             Self::SearchCompetitions { .. } => Duration::from_secs(HOUR_IN_S * 12),
@@ -115,6 +129,8 @@ impl CachedRequest {
             Self::GetAthleteProfile { .. } => Duration::from_secs(HOUR_IN_S * 12),
             Self::GetAthleteProfileMobile { .. } => Duration::from_secs(HOUR_IN_S * 12),
             Self::SearchCompetitionsMobile { .. } => Duration::from_secs(HOUR_IN_S * 12),
+            Self::GetCompetitionDetailMobile { .. } => Duration::from_secs(HOUR_IN_S * 12),
+            Self::GetCompetitionProgramMobile { .. } => Duration::from_secs(HOUR_IN_S * 12),
         }
     }
 
@@ -167,6 +183,12 @@ impl CachedRequest {
                 .await
                 .map(|v| rocket::serde::json::to_string(&v).unwrap())
             }
+            Self::GetCompetitionDetailMobile { id } => atletiek_nu_api::get_competition_detail_mobile(*id)
+                .await
+                .map(|v| rocket::serde::json::to_string(&v).unwrap()),
+            Self::GetCompetitionProgramMobile { id } => atletiek_nu_api::get_competition_program_mobile(*id)
+                .await
+                .map(|v| rocket::serde::json::to_string(&v).unwrap()),
         } {
             Ok(v) => {
                 cache.insert(self, v.clone());

--- a/api/src/cache/mod.rs
+++ b/api/src/cache/mod.rs
@@ -40,6 +40,15 @@ pub enum CachedRequest {
     GetAthleteProfile {
         id: u32
     },
+    GetAthleteProfileMobile {
+        id: u32
+    },
+    SearchCompetitionsMobile {
+        country: String,
+        start: NaiveDate,
+        end: NaiveDate,
+        query: String,
+    },
 }
 
 #[derive(Serialize)]
@@ -81,7 +90,20 @@ impl CachedRequest {
     }
     pub fn new_get_athlete_profile(id: u32) -> Self {
         Self::GetAthleteProfile{ id }
+    }
 
+    pub fn new_get_athlete_profile_mobile(id: u32) -> Self {
+        Self::GetAthleteProfileMobile { id }
+    }
+
+    pub fn new_search_competitions_mobile(
+        country: String,
+        start: NaiveDate,
+        end: NaiveDate,
+        query: Option<String>,
+    ) -> Self {
+        let query = query.unwrap_or_default().to_lowercase();
+        Self::SearchCompetitionsMobile { country, start, end, query }
     }
 
     fn cache_duration(&self) -> Duration {
@@ -91,6 +113,8 @@ impl CachedRequest {
             Self::GetCompetitionResults { .. } => Duration::from_secs(HOUR_IN_S * 24),
             Self::SearchAthletes { .. } => Duration::from_secs(HOUR_IN_S * 12),
             Self::GetAthleteProfile { .. } => Duration::from_secs(HOUR_IN_S * 12),
+            Self::GetAthleteProfileMobile { .. } => Duration::from_secs(HOUR_IN_S * 12),
+            Self::SearchCompetitionsMobile { .. } => Duration::from_secs(HOUR_IN_S * 12),
         }
     }
 
@@ -129,7 +153,20 @@ impl CachedRequest {
                 .map(|v| rocket::serde::json::to_string(&v).unwrap()),
             Self::GetAthleteProfile { id } => atletiek_nu_api::get_athlete_profile(*id)
                 .await
+                .map(|v| rocket::serde::json::to_string(&v).unwrap()),
+            Self::GetAthleteProfileMobile { id } => atletiek_nu_api::get_athlete_profile_mobile(*id)
+                .await
+                .map(|v| rocket::serde::json::to_string(&v).unwrap()),
+            Self::SearchCompetitionsMobile { country, start, end, query } => {
+                atletiek_nu_api::search_competitions_mobile(
+                    country,
+                    start.to_owned(),
+                    end.to_owned(),
+                    query,
+                )
+                .await
                 .map(|v| rocket::serde::json::to_string(&v).unwrap())
+            }
         } {
             Ok(v) => {
                 cache.insert(self, v.clone());

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -122,6 +122,8 @@ async fn main() -> Result<(), rocket::Error> {
                 route::get_results,
                 route::search_athletes,
                 route::get_athlete_profile,
+                route::get_athlete_profile_mobile,
+                route::search_competitions_mobile,
             ],
         )
         .manage(cache_managed)

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -124,6 +124,8 @@ async fn main() -> Result<(), rocket::Error> {
                 route::get_athlete_profile,
                 route::get_athlete_profile_mobile,
                 route::search_competitions_mobile,
+                route::get_competition_detail_mobile,
+                route::get_competition_program_mobile,
             ],
         )
         .manage(cache_managed)

--- a/api/src/route.rs
+++ b/api/src/route.rs
@@ -42,3 +42,26 @@ pub async fn get_athlete_profile(id: u32, cache: RequestCache, ratelimiter: &Sta
     let req = CachedRequest::new_get_athlete_profile(id);
     req.run(cache, ratelimiter).await
 }
+
+/// Mobile endpoint: athlete profile with personal bests and per-event performance history.
+/// Not affected by Cloudflare Turnstile anti-bot protection.
+#[get("/mobile/athletes/profile/<id>")]
+pub async fn get_athlete_profile_mobile(id: u32, cache: RequestCache, ratelimiter: &State<RateLimiter>) -> ApiResponse {
+    let req = CachedRequest::new_get_athlete_profile_mobile(id);
+    req.run(cache, ratelimiter).await
+}
+
+/// Mobile endpoint: search competitions by country and date range.
+/// Not affected by Cloudflare Turnstile anti-bot protection.
+#[get("/mobile/competitions/search?<country>&<start>&<end>&<query>")]
+pub async fn search_competitions_mobile(
+    country: String,
+    start: RequestNaiveDate,
+    end: RequestNaiveDate,
+    query: Option<String>,
+    cache: RequestCache,
+    ratelimiter: &State<RateLimiter>,
+) -> ApiResponse {
+    let req = CachedRequest::new_search_competitions_mobile(country, start.0, end.0, query);
+    req.run(cache, ratelimiter).await
+}

--- a/api/src/route.rs
+++ b/api/src/route.rs
@@ -65,3 +65,19 @@ pub async fn search_competitions_mobile(
     let req = CachedRequest::new_search_competitions_mobile(country, start.0, end.0, query);
     req.run(cache, ratelimiter).await
 }
+
+/// Mobile endpoint: competition detail with categories, events, and pricing.
+/// Not affected by Cloudflare Turnstile anti-bot protection.
+#[get("/mobile/competitions/detail/<id>")]
+pub async fn get_competition_detail_mobile(id: u32, cache: RequestCache, ratelimiter: &State<RateLimiter>) -> ApiResponse {
+    let req = CachedRequest::new_get_competition_detail_mobile(id);
+    req.run(cache, ratelimiter).await
+}
+
+/// Mobile endpoint: full competition program (gender → category → event groups → events).
+/// Not affected by Cloudflare Turnstile anti-bot protection.
+#[get("/mobile/competitions/program/<id>")]
+pub async fn get_competition_program_mobile(id: u32, cache: RequestCache, ratelimiter: &State<RateLimiter>) -> ApiResponse {
+    let req = CachedRequest::new_get_competition_program_mobile(id);
+    req.run(cache, ratelimiter).await
+}

--- a/atletiek-nu-api/src/lib.rs
+++ b/atletiek-nu-api/src/lib.rs
@@ -14,6 +14,8 @@ use urlencoding;
 
 pub use crate::models::athlete_event_result::AthleteEventResults;
 use crate::models::athlete_list::AthleteList;
+pub use crate::models::athlete_profile_mobile::MobileAthleteProfile;
+pub use crate::models::competitions_list_mobile::MobileCompetitionsList;
 use crate::models::registrations_list::RegistrationsList;
 use crate::traits::CompetitionID;
 pub use chrono;
@@ -130,6 +132,55 @@ pub async fn get_athlete_profile(athlete_id: u32) -> anyhow::Result<AthleteProfi
     let url = format!("https://www.athletics.app/atleet/profiel/{}", athlete_id);
     let body = send_request(&url).await?;
     models::athlete_profile::parse(Html::parse_document(&body))
+}
+
+/// Fetch an athlete's profile using the mobile endpoint (bypasses Cloudflare Turnstile).
+///
+/// This makes two requests:
+/// 1. `do=get` to retrieve the athlete's name
+/// 2. `do=records` to retrieve personal bests and per-event performance history
+///
+/// The mobile endpoint provides richer data than the web profile, including
+/// wind speed, location, and country for each performance in the history.
+pub async fn get_athlete_profile_mobile(athlete_id: u32) -> anyhow::Result<MobileAthleteProfile> {
+    // Fetch athlete name from the profile endpoint
+    let name_url = format!(
+        "https://www.athletics.app/athleteapp.php?page=athlete&do=get&ranglijst_score_koppel_id={}&language=en_GB&version=1.16",
+        athlete_id
+    );
+    let name_body = send_request(&name_url).await?;
+    let name = models::athlete_profile_mobile::parse_name(Html::parse_fragment(&name_body))?;
+
+    // Fetch records (personal bests + history)
+    let records_url = format!(
+        "https://www.athletics.app/athleteapp.php?page=athlete&do=records&ranglijst_score_koppel_id={}&language=en_GB&version=1.16",
+        athlete_id
+    );
+    let records_body = send_request(&records_url).await?;
+    models::athlete_profile_mobile::parse(Html::parse_fragment(&records_body), name)
+}
+
+/// Search for competitions using the mobile endpoint (bypasses Cloudflare Turnstile).
+///
+/// Unlike `search_competitions_for_time_period` which uses `feeder.php` (blocked by
+/// Cloudflare), this uses the `athleteapp.php` mobile endpoint.
+pub async fn search_competitions_mobile(
+    country: &str,
+    start: NaiveDate,
+    end: NaiveDate,
+    q: &str,
+) -> anyhow::Result<MobileCompetitionsList> {
+    let start_ts = NaiveDateTime::new(start, NaiveTime::from_hms_opt(0, 0, 0).unwrap()).and_utc().timestamp();
+    let end_ts = NaiveDateTime::new(end, NaiveTime::from_hms_opt(0, 0, 0).unwrap()).and_utc().timestamp();
+    let url = format!(
+        "https://www.athletics.app/athleteapp.php?page=events&do=searchresults&country_iso2={}&search={}&predefinedSearchTemplate=0&startDate={}&endDate={}&language=en_GB&version=1.16&improvePerformance=0",
+        urlencoding::encode(country),
+        urlencoding::encode(q),
+        start_ts,
+        end_ts
+    );
+    let body = send_request(&url).await?;
+    models::competitions_list_mobile::parse(Html::parse_fragment(&body))
 }
 
 pub async fn get_competitions_for_time_period(

--- a/atletiek-nu-api/src/lib.rs
+++ b/atletiek-nu-api/src/lib.rs
@@ -15,6 +15,8 @@ use urlencoding;
 pub use crate::models::athlete_event_result::AthleteEventResults;
 use crate::models::athlete_list::AthleteList;
 pub use crate::models::athlete_profile_mobile::MobileAthleteProfile;
+pub use crate::models::competition_detail_mobile::MobileCompetitionDetail;
+pub use crate::models::competition_program_mobile::MobileCompetitionProgram;
 pub use crate::models::competitions_list_mobile::MobileCompetitionsList;
 use crate::models::registrations_list::RegistrationsList;
 use crate::traits::CompetitionID;
@@ -188,6 +190,32 @@ pub async fn search_competitions_mobile(
     );
     let body = send_request(&url).await?;
     models::competitions_list_mobile::parse(Html::parse_fragment(&body))
+}
+
+/// Fetch competition detail using the mobile endpoint (bypasses Cloudflare Turnstile).
+///
+/// Returns metadata (name, date, location, description) and the categories table
+/// showing which age groups can participate with their available events and pricing.
+pub async fn get_competition_detail_mobile(event_id: u32) -> anyhow::Result<MobileCompetitionDetail> {
+    let url = format!(
+        "https://www.athletics.app/athleteapp.php?page=event&do=get&event_id={}&language=en_GB&version=1.16",
+        event_id
+    );
+    let body = send_request(&url).await?;
+    models::competition_detail_mobile::parse(Html::parse_fragment(&body))
+}
+
+/// Fetch competition program using the mobile endpoint (bypasses Cloudflare Turnstile).
+///
+/// Returns the full program: gender groups → age categories → event groups → events.
+/// More detailed than the categories table from `get_competition_detail_mobile`.
+pub async fn get_competition_program_mobile(event_id: u32) -> anyhow::Result<MobileCompetitionProgram> {
+    let url = format!(
+        "https://www.athletics.app/athleteapp.php?page=event&do=program&event_id={}&language=en_GB&version=1.16",
+        event_id
+    );
+    let body = send_request(&url).await?;
+    models::competition_program_mobile::parse(Html::parse_fragment(&body))
 }
 
 pub async fn get_competitions_for_time_period(

--- a/atletiek-nu-api/src/models/athlete_profile_mobile.rs
+++ b/atletiek-nu-api/src/models/athlete_profile_mobile.rs
@@ -1,0 +1,369 @@
+//! Parser for the mobile endpoint: `athleteapp.php?page=athlete&do=records`
+//!
+//! This endpoint is NOT protected by Cloudflare Turnstile and returns richer
+//! data than the desktop profile page, including per-event performance history
+//! with wind speed, location, country, and delta progression.
+//!
+//! HTML structure:
+//!   - First `div.list-athlete-results > ul` = Personal Records list
+//!   - `div.tabs.graphTabs > div[id^=tab-eventgraph-]` = history tabs per event
+//!   - Each history tab contains a `div.list-athlete-results > ul` with performances
+
+use log::trace;
+use regex::Regex;
+use scraper::{Html, Selector};
+use serde::{Deserialize, Serialize};
+
+const REGEX_WIND: &str = r#"([+-]?\d+[.,]\d+)\s*m/s"#;
+const REGEX_COUNTRY_CODE: &str = r#"/([a-z]{2})\.png"#;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MobileAthleteProfile {
+    pub name: String,
+    pub personal_bests: Vec<MobilePersonalBest>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MobilePersonalBest {
+    pub event: String,
+    pub performance: String,
+    pub performance_value: f32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub wind_speed: Option<f32>,
+    pub hand_measured: bool,
+    pub location: String,
+    pub country_code: String,
+    pub date: String,
+    pub not_important: bool,
+    pub indoor: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub attribute: Option<String>,
+    pub history: Vec<PerformanceHistoryEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PerformanceHistoryEntry {
+    pub performance: String,
+    pub performance_value: f32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub wind_speed: Option<f32>,
+    pub hand_measured: bool,
+    pub location: String,
+    pub country_code: String,
+    pub date: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub delta: Option<String>,
+}
+
+/// Data extracted from a single `<li>` element (used for both PRs and history entries).
+struct ParsedLi {
+    event_name: String,
+    performance: String,
+    performance_value: f32,
+    wind_speed: Option<f32>,
+    hand_measured: bool,
+    location: String,
+    country_code: String,
+    date: String,
+    not_important: bool,
+    indoor: bool,
+    attribute: Option<String>,
+}
+
+fn parse_wind(text: &str) -> Option<f32> {
+    let re = Regex::new(REGEX_WIND).unwrap();
+    re.captures(text).and_then(|cap| {
+        cap[1].replace(",", ".").parse::<f32>().ok()
+    })
+}
+
+fn extract_country_code(html: &str) -> String {
+    let re = Regex::new(REGEX_COUNTRY_CODE).unwrap();
+    re.captures(html)
+        .map(|cap| cap[1].to_string())
+        .unwrap_or_default()
+}
+
+fn parse_performance_value(text: &str) -> f32 {
+    let text = text.trim().trim_end_matches('h');
+    if text.is_empty() || text == "DNF" || text == "DNS" || text == "DQ" || text == "NM" || text == "NH" {
+        return 0.0;
+    }
+
+    let parts: Vec<&str> = text.split(':').collect();
+    match parts.len() {
+        3 => {
+            let hours: f32 = parts[0].parse().unwrap_or(0.0);
+            let minutes: f32 = parts[1].parse().unwrap_or(0.0);
+            let seconds: f32 = parts[2].replace(",", ".").parse().unwrap_or(0.0);
+            hours * 3600.0 + minutes * 60.0 + seconds
+        }
+        2 => {
+            let minutes: f32 = parts[0].parse().unwrap_or(0.0);
+            let seconds: f32 = parts[1].replace(",", ".").parse().unwrap_or(0.0);
+            minutes * 60.0 + seconds
+        }
+        _ => text.replace(",", ".").parse().unwrap_or(0.0),
+    }
+}
+
+fn parse_li(li: &scraper::ElementRef) -> Option<ParsedLi> {
+    let onderdeel_sel = Selector::parse(".onderdeel").unwrap();
+    let item_title_sel = Selector::parse(".item-title").unwrap();
+    let item_footer_sel = Selector::parse(".item-footer").unwrap();
+    let item_footer_span_sel = Selector::parse(".item-footer > span").unwrap();
+    let result_footer_sel = Selector::parse(".result-footer-details").unwrap();
+    let location_sel = Selector::parse(".location").unwrap();
+    let badge_sel = Selector::parse(".badge").unwrap();
+    let flagicon_sel = Selector::parse("img.flagicon").unwrap();
+
+    // Event name
+    let onderdeel = li.select(&onderdeel_sel).next()?;
+    let event_name: String = onderdeel
+        .text()
+        .filter(|t| {
+            let trimmed = t.trim();
+            !trimmed.is_empty()
+                && !trimmed.contains('\n')
+                // skip badge text like "indoor"
+                && trimmed.len() > 1
+        })
+        .next()
+        .unwrap_or("")
+        .trim()
+        .to_string();
+
+    // Indoor detection
+    let indoor = onderdeel
+        .select(&badge_sel)
+        .next()
+        .map(|b| b.text().any(|t| t.to_lowercase().contains("indoor")))
+        .unwrap_or(false);
+
+    // Attribute from footer
+    let attribute = onderdeel
+        .select(&item_footer_sel)
+        .next()
+        .and_then(|f| {
+            let text = f.text().collect::<String>().trim().to_string();
+            if text.is_empty() { None } else { Some(text) }
+        });
+
+    // Performance
+    let perf_div = li.select(&item_title_sel).next()?;
+    let perf_text: String = perf_div
+        .text()
+        .filter(|t| !t.trim().is_empty())
+        .next()
+        .unwrap_or("")
+        .trim()
+        .to_string();
+
+    let hand_measured = perf_text.ends_with('h');
+    let performance_value = parse_performance_value(&perf_text);
+
+    // Wind speed: try `.item-footer > span` (history format) then `.result-footer-details` (PR format)
+    let wind_speed = perf_div
+        .select(&item_footer_span_sel)
+        .next()
+        .or_else(|| perf_div.select(&result_footer_sel).next())
+        .or_else(|| perf_div.select(&item_footer_sel).next())
+        .and_then(|el| {
+            let text = el.text().collect::<String>();
+            let text = text.trim();
+            if text == "n/a m/s" || text.is_empty() {
+                return None;
+            }
+            parse_wind(text)
+        });
+
+    // Date and location
+    let mut date = String::new();
+    let mut location = String::new();
+    let mut country_code = String::new();
+
+    if let Some(loc_div) = li.select(&location_sel).next() {
+        date = loc_div
+            .text()
+            .filter(|t| !t.trim().is_empty())
+            .next()
+            .unwrap_or("")
+            .trim()
+            .to_string();
+
+        if let Some(footer) = loc_div.select(&result_footer_sel).next() {
+            location = footer
+                .text()
+                .collect::<String>()
+                .trim()
+                .to_string();
+
+            if let Some(img) = footer.select(&flagicon_sel).next() {
+                if let Some(src) = img.value().attr("src") {
+                    country_code = extract_country_code(src);
+                }
+            }
+        }
+    }
+
+    let not_important = li
+        .value()
+        .attr("class")
+        .map(|c| c.contains("notThatImportant"))
+        .unwrap_or(false);
+
+    Some(ParsedLi {
+        event_name,
+        performance: perf_text,
+        performance_value,
+        wind_speed,
+        hand_measured,
+        location,
+        country_code,
+        date,
+        not_important,
+        indoor,
+        attribute,
+    })
+}
+
+fn parse_history_tab(tab: &scraper::ElementRef) -> Vec<PerformanceHistoryEntry> {
+    let li_sel = Selector::parse("li").unwrap();
+    let mut entries = Vec::new();
+
+    for li in tab.select(&li_sel) {
+        if li.value().attr("class").map(|c| c.contains("list-header")).unwrap_or(false) {
+            continue;
+        }
+        if let Some(parsed) = parse_li(&li) {
+            entries.push(PerformanceHistoryEntry {
+                performance: parsed.performance,
+                performance_value: parsed.performance_value,
+                wind_speed: parsed.wind_speed,
+                hand_measured: parsed.hand_measured,
+                location: parsed.location,
+                country_code: parsed.country_code,
+                date: parsed.date,
+                delta: if parsed.event_name.is_empty() { None } else { Some(parsed.event_name) },
+            });
+        }
+    }
+
+    entries
+}
+
+/// Parse the mobile athlete records page.
+///
+/// The `name` parameter should be fetched separately from the `do=get` endpoint.
+pub fn parse(html: Html, name: String) -> anyhow::Result<MobileAthleteProfile> {
+    let list_sel = Selector::parse("div.list-athlete-results").unwrap();
+    let li_sel = Selector::parse("ul > li").unwrap();
+    let tab_sel = Selector::parse("div.tabs.graphTabs > div[id^='tab-eventgraph-']").unwrap();
+
+    // First div.list-athlete-results contains the PR list
+    let pr_container = html
+        .select(&list_sel)
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("no div.list-athlete-results found"))?;
+
+    let mut personal_bests = Vec::new();
+
+    for li in pr_container.select(&li_sel) {
+        if li.value().attr("class").map(|c| c.contains("list-header")).unwrap_or(false) {
+            continue;
+        }
+        if let Some(parsed) = parse_li(&li) {
+            personal_bests.push(MobilePersonalBest {
+                event: parsed.event_name,
+                performance: parsed.performance,
+                performance_value: parsed.performance_value,
+                wind_speed: parsed.wind_speed,
+                hand_measured: parsed.hand_measured,
+                location: parsed.location,
+                country_code: parsed.country_code,
+                date: parsed.date,
+                not_important: parsed.not_important,
+                indoor: parsed.indoor,
+                attribute: parsed.attribute,
+                history: Vec::new(),
+            });
+        }
+    }
+
+    // History tabs: div.tabs.graphTabs > div[id^=tab-eventgraph-]
+    let tabs: Vec<_> = html.select(&tab_sel).collect();
+
+    // Match each tab to its PR by checking if the PR's performance+date appear in the tab
+    let mut tab_idx = 0;
+    let mut assigned: std::collections::HashSet<usize> = std::collections::HashSet::new();
+
+    for pb in personal_bests.iter_mut() {
+        if tab_idx >= tabs.len() {
+            break;
+        }
+
+        let history = parse_history_tab(&tabs[tab_idx]);
+
+        // Verify this tab matches this PR
+        let matches = history.iter().any(|h| {
+            h.performance == pb.performance && h.date == pb.date
+        });
+
+        if matches {
+            pb.history = history;
+            assigned.insert(tab_idx);
+            tab_idx += 1;
+        } else {
+            // Look ahead up to 3 tabs for a match
+            let mut found = false;
+            for look in tab_idx..std::cmp::min(tab_idx + 3, tabs.len()) {
+                if assigned.contains(&look) {
+                    continue;
+                }
+                let look_history = parse_history_tab(&tabs[look]);
+                if look_history.iter().any(|h| {
+                    h.performance == pb.performance && h.date == pb.date
+                }) {
+                    pb.history = look_history;
+                    assigned.insert(look);
+                    if look == tab_idx {
+                        tab_idx += 1;
+                    }
+                    found = true;
+                    break;
+                }
+            }
+            if !found {
+                trace!("No matching history tab for PR: {} {}", pb.event, pb.performance);
+            }
+        }
+    }
+
+    Ok(MobileAthleteProfile {
+        name,
+        personal_bests,
+    })
+}
+
+/// Parse the athlete name from the `do=get` mobile endpoint.
+pub fn parse_name(html: Html) -> anyhow::Result<String> {
+    let title_sel = Selector::parse("h3.no-margin-bottom").unwrap();
+    let name = html
+        .select(&title_sel)
+        .next()
+        .map(|el| el.text().collect::<String>().trim().replace("  ", " "))
+        .unwrap_or_default();
+
+    if name.is_empty() {
+        // Fallback: try .title
+        let fallback_sel = Selector::parse(".title").unwrap();
+        let name = html
+            .select(&fallback_sel)
+            .next()
+            .map(|el| el.text().collect::<String>().trim().to_string())
+            .ok_or_else(|| anyhow::anyhow!("could not find athlete name in mobile profile"))?;
+        Ok(name)
+    } else {
+        Ok(name)
+    }
+}

--- a/atletiek-nu-api/src/models/competition_detail_mobile.rs
+++ b/atletiek-nu-api/src/models/competition_detail_mobile.rs
@@ -1,0 +1,296 @@
+//! Parser for the mobile competition detail endpoint:
+//! `athleteapp.php?page=event&do=get&event_id=<id>`
+//!
+//! This endpoint is NOT protected by Cloudflare Turnstile.
+//! It returns competition metadata (name, date, location, description)
+//! and a categories table showing which age groups can participate
+//! with their available events and pricing.
+
+use regex::Regex;
+use scraper::{Html, Selector};
+use serde::{Deserialize, Serialize};
+
+const REGEX_COUNTRY_CODE: &str = r#"/([a-z]{2})\.png"#;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MobileCompetitionDetail {
+    pub name: String,
+    pub date: String,
+    pub location: String,
+    pub country_code: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    pub federation_recognized: bool,
+    pub categories: Vec<CompetitionCategoryGroup>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CompetitionCategoryGroup {
+    /// Age group names, e.g. ["Senior Men", "U20 Men", "U18 Men"]
+    pub age_groups: Vec<String>,
+    /// Event groups available for these categories
+    pub event_groups: Vec<CompetitionEventGroup>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CompetitionEventGroup {
+    /// e.g. "Sprint", "Mid. dist.", "Throw", "Jump", "Combined-events"
+    pub label: String,
+    /// Event names, e.g. ["100m", "200m"]
+    pub events: Vec<String>,
+    /// Price per event, e.g. "€5.00"
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub price: Option<String>,
+    /// Capacity info extracted from tooltips
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub capacity_info: Vec<String>,
+}
+
+pub fn parse(html: Html) -> anyhow::Result<MobileCompetitionDetail> {
+    let name_sel = Selector::parse("h2.no-margin").unwrap();
+    let header_sel = Selector::parse(".event-header-container").unwrap();
+    let header_p_sel = Selector::parse("p").unwrap();
+    let flag_sel = Selector::parse("img.flagicon").unwrap();
+    let desc_sel = Selector::parse(".event-description").unwrap();
+    let badge_sel = Selector::parse("i.atletiekunie").unwrap();
+    let table_sel = Selector::parse("table.categorieenonderdelenpakket").unwrap();
+    let tr_sel = Selector::parse("tr").unwrap();
+    let td_sel = Selector::parse("td").unwrap();
+    let tipped_sel = Selector::parse("span.tipped").unwrap();
+
+    let re_country = Regex::new(REGEX_COUNTRY_CODE).unwrap();
+
+    // Name
+    let name = html
+        .select(&name_sel)
+        .next()
+        .map(|el| {
+            el.text()
+                .filter(|t| !t.trim().is_empty())
+                .next()
+                .unwrap_or("")
+                .trim()
+                .to_string()
+        })
+        .unwrap_or_default();
+
+    // Header: location and date
+    let mut location = String::new();
+    let mut date = String::new();
+    let mut country_code = String::new();
+
+    if let Some(header) = html.select(&header_sel).next() {
+        let paragraphs: Vec<_> = header.select(&header_p_sel).collect();
+
+        if let Some(loc_p) = paragraphs.first() {
+            location = loc_p
+                .text()
+                .collect::<String>()
+                .trim()
+                .to_string();
+
+            if let Some(img) = loc_p.select(&flag_sel).next() {
+                if let Some(src) = img.value().attr("src") {
+                    if let Some(cap) = re_country.captures(src) {
+                        country_code = cap[1].to_string();
+                    }
+                }
+            }
+        }
+
+        if let Some(date_p) = paragraphs.get(1) {
+            date = date_p
+                .text()
+                .collect::<String>()
+                .trim()
+                // Clean up template markers like {{_ "u"}}
+                .replace("{{_ \"u\"}}", "")
+                .trim()
+                .to_string();
+        }
+    }
+
+    // Description
+    let description = html
+        .select(&desc_sel)
+        .next()
+        .map(|el| el.text().collect::<String>().trim().to_string())
+        .filter(|s| !s.is_empty());
+
+    // Federation recognized
+    let federation_recognized = html.select(&badge_sel).next().is_some();
+
+    // Categories table
+    let mut categories = Vec::new();
+
+    if let Some(table) = html.select(&table_sel).next() {
+        let rows: Vec<_> = table.select(&tr_sel).collect();
+        let mut i = 0;
+
+        // Skip header row
+        if !rows.is_empty() {
+            i = 1;
+        }
+
+        while i < rows.len() {
+            let cells: Vec<_> = rows[i].select(&td_sel).collect();
+            if cells.is_empty() {
+                i += 1;
+                continue;
+            }
+
+            // Check if first cell has rowspan (category group start)
+            let first_cell = &cells[0];
+            let has_categories = first_cell.select(&tipped_sel).next().is_some()
+                && first_cell
+                    .value()
+                    .attr("rowspan")
+                    .is_some();
+
+            if has_categories || (cells.len() >= 4 && first_cell.select(&tipped_sel).next().is_some()) {
+                let age_groups: Vec<String> = first_cell
+                    .select(&tipped_sel)
+                    .map(|s| {
+                        s.value()
+                            .attr("title")
+                            .unwrap_or("")
+                            .trim()
+                            .to_string()
+                    })
+                    .filter(|s| !s.is_empty())
+                    .collect();
+
+                let rowspan: usize = first_cell
+                    .value()
+                    .attr("rowspan")
+                    .and_then(|r| r.parse().ok())
+                    .unwrap_or(1);
+
+                let mut event_groups = Vec::new();
+
+                // Parse this row's event (cells offset by 1 because of category cell)
+                parse_event_row(&cells[1..], &tipped_sel, &mut event_groups);
+
+                // Parse subsequent rows that belong to this rowspan
+                for j in 1..rowspan {
+                    if i + j < rows.len() {
+                        let sub_cells: Vec<_> = rows[i + j].select(&td_sel).collect();
+                        if !sub_cells.is_empty() {
+                            parse_event_row(&sub_cells, &tipped_sel, &mut event_groups);
+                        }
+                    }
+                }
+
+                categories.push(CompetitionCategoryGroup {
+                    age_groups,
+                    event_groups,
+                });
+
+                i += rowspan;
+            } else {
+                i += 1;
+            }
+        }
+    }
+
+    Ok(MobileCompetitionDetail {
+        name,
+        date,
+        location,
+        country_code,
+        description,
+        federation_recognized,
+        categories,
+    })
+}
+
+fn parse_event_row(
+    cells: &[scraper::ElementRef],
+    tipped_sel: &Selector,
+    event_groups: &mut Vec<CompetitionEventGroup>,
+) {
+    if cells.is_empty() {
+        return;
+    }
+
+    // First cell: label (e.g. "Sprint:", "Mid. dist.:", "Combined-events:")
+    let label = cells[0]
+        .text()
+        .collect::<String>()
+        .trim()
+        .trim_end_matches(':')
+        .to_string();
+
+    // Second cell (if exists): events + capacity tooltips
+    let mut events = Vec::new();
+    let mut capacity_info = Vec::new();
+
+    if cells.len() > 1 {
+        // Events from tipped spans (tooltip = event full name)
+        let tipped: Vec<_> = cells[1].select(tipped_sel).collect();
+
+        // Check if the tipped spans contain event names or capacity info
+        for span in &tipped {
+            let title = span
+                .value()
+                .attr("title")
+                .unwrap_or("")
+                .trim()
+                .to_string();
+
+            if title.contains("starting places") || title.contains("reserve") {
+                capacity_info.push(title);
+            } else if !title.is_empty() {
+                events.push(title);
+            }
+        }
+
+        // If no event names from tooltips, try the cell text
+        if events.is_empty() {
+            let text = cells[1].text().collect::<String>();
+            let text = text.trim();
+            if !text.is_empty()
+                && !text.contains("starting places")
+                && !text.contains("reserve")
+            {
+                // Split by comma for abbreviated event lists like "100m, 200m"
+                for part in text.split(',') {
+                    let part = part.trim();
+                    if !part.is_empty() {
+                        events.push(part.to_string());
+                    }
+                }
+            }
+        }
+
+        // Also check cells[1] for capacity info if not found yet
+        if capacity_info.is_empty() {
+            for span in cells[1].select(tipped_sel) {
+                let title = span
+                    .value()
+                    .attr("title")
+                    .unwrap_or("")
+                    .trim()
+                    .to_string();
+                if title.contains("starting places") || title.contains("reserve") {
+                    capacity_info.push(title);
+                }
+            }
+        }
+    }
+
+    // Price from last cell
+    let price = cells
+        .last()
+        .map(|c| c.text().collect::<String>().trim().to_string())
+        .filter(|s| s.contains('€') || s.contains("free") || s.contains("gratis"));
+
+    if !label.is_empty() || !events.is_empty() {
+        event_groups.push(CompetitionEventGroup {
+            label,
+            events,
+            price,
+            capacity_info,
+        });
+    }
+}

--- a/atletiek-nu-api/src/models/competition_program_mobile.rs
+++ b/atletiek-nu-api/src/models/competition_program_mobile.rs
@@ -1,0 +1,207 @@
+//! Parser for the mobile competition program endpoint:
+//! `athleteapp.php?page=event&do=program&event_id=<id>`
+//!
+//! This endpoint is NOT protected by Cloudflare Turnstile.
+//! It returns the full program: gender groups → age categories → event groups → events.
+//! More detailed than the `do=get` categories table.
+
+use scraper::{Html, Selector};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MobileCompetitionProgram {
+    pub gender_groups: Vec<GenderGroup>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GenderGroup {
+    /// "Men" or "Women"
+    pub gender: String,
+    pub categories: Vec<ProgramCategory>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProgramCategory {
+    /// e.g. "U18 Men", "Senior Women", "U10 Boys"
+    pub name: String,
+    pub event_groups: Vec<ProgramEventGroup>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProgramEventGroup {
+    /// e.g. "Track Events", "Field Events", "Combined-events"
+    pub label: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub price: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub capacity: Option<String>,
+    pub events: Vec<String>,
+}
+
+pub fn parse(html: Html) -> anyhow::Result<MobileCompetitionProgram> {
+    let page_sel = Selector::parse(".page-content.page-event-program").unwrap();
+    let group_title_sel = Selector::parse(":scope > ul > li.list-group-title").unwrap();
+    let accordion_sel = Selector::parse(":scope > ul > li.accordion-item").unwrap();
+    let item_title_sel = Selector::parse(".item-title").unwrap();
+    let content_sel = Selector::parse(".accordion-item-content").unwrap();
+    let inner_group_sel = Selector::parse(".list-group").unwrap();
+    let inner_title_sel = Selector::parse("li.list-group-title").unwrap();
+    let inner_item_sel = Selector::parse("li:not(.list-group-title)").unwrap();
+    let icon_mars_sel = Selector::parse("i.fa-mars").unwrap();
+    let icon_venus_sel = Selector::parse("i.fa-venus").unwrap();
+    let price_sel = Selector::parse(".meerkamp-kosten-label").unwrap();
+
+    // The page has a specific structure - try parsing from page-content first
+    // If that fails, parse the whole document
+    let root = html
+        .select(&page_sel)
+        .next();
+
+    // Collect all top-level list-groups from the HTML
+    // The structure is: div.list > div.list-group (with gender title) > ul > li.accordion-item
+    let all_groups_sel = Selector::parse("div.list:not(.inset) > .list-group").unwrap();
+
+    let groups: Vec<_> = if let Some(root_el) = root {
+        root_el.select(&all_groups_sel).collect()
+    } else {
+        html.select(&all_groups_sel).collect()
+    };
+
+    let mut gender_groups = Vec::new();
+
+    for group in groups {
+        // Check if this is a gender group (has mars/venus icon in title)
+        let title_el = match group.select(&group_title_sel).next() {
+            Some(t) => t,
+            None => continue,
+        };
+
+        let has_mars = title_el.select(&icon_mars_sel).next().is_some();
+        let has_venus = title_el.select(&icon_venus_sel).next().is_some();
+
+        if !has_mars && !has_venus {
+            // This is a sub-group (Track Events, Field Events, etc.), not a gender group
+            continue;
+        }
+
+        let gender = if has_mars {
+            "Men".to_string()
+        } else {
+            "Women".to_string()
+        };
+
+        let mut categories = Vec::new();
+
+        for accordion in group.select(&accordion_sel) {
+            let cat_name = match accordion.select(&item_title_sel).next() {
+                Some(t) => t.text().collect::<String>().trim().to_string(),
+                None => continue,
+            };
+
+            let mut event_groups = Vec::new();
+
+            if let Some(content) = accordion.select(&content_sel).next() {
+                for inner_group in content.select(&inner_group_sel) {
+                    let label_el = match inner_group.select(&inner_title_sel).next() {
+                        Some(t) => t,
+                        None => continue,
+                    };
+
+                    // Extract label (clean up price and capacity text)
+                    let label_text = label_el
+                        .text()
+                        .collect::<String>();
+
+                    // Price from dedicated span
+                    let price = label_el
+                        .select(&price_sel)
+                        .next()
+                        .map(|p| p.text().collect::<String>().trim().to_string());
+
+                    // Clean label: remove price text and capacity info
+                    let label = label_text
+                        .trim()
+                        .to_string();
+
+                    // Extract just the event group name (before price/capacity)
+                    let clean_label = if let Some(price_str) = &price {
+                        label
+                            .split(price_str.as_str())
+                            .next()
+                            .unwrap_or(&label)
+                            .trim()
+                            .to_string()
+                    } else {
+                        // Try to split at common capacity indicators
+                        let label_clean = label
+                            .split(|c: char| c.is_ascii_digit())
+                            .next()
+                            .unwrap_or(&label)
+                            .trim()
+                            .to_string();
+                        if label_clean.is_empty() {
+                            label.clone()
+                        } else {
+                            label_clean
+                        }
+                    };
+
+                    // Capacity info (text after the label)
+                    let capacity = {
+                        let full = label_text.trim().to_string();
+                        let after_label = if let Some(price_str) = &price {
+                            full.split(price_str.as_str())
+                                .nth(1)
+                                .unwrap_or("")
+                                .trim()
+                                .to_string()
+                        } else {
+                            String::new()
+                        };
+                        if after_label.is_empty() {
+                            None
+                        } else {
+                            Some(after_label)
+                        }
+                    };
+
+                    // Events
+                    let events: Vec<String> = inner_group
+                        .select(&inner_item_sel)
+                        .filter_map(|li| {
+                            li.select(&item_title_sel)
+                                .next()
+                                .map(|t| t.text().collect::<String>().trim().to_string())
+                        })
+                        .filter(|s| !s.is_empty())
+                        .collect();
+
+                    if !events.is_empty() || !clean_label.is_empty() {
+                        event_groups.push(ProgramEventGroup {
+                            label: clean_label,
+                            price,
+                            capacity,
+                            events,
+                        });
+                    }
+                }
+            }
+
+            if !cat_name.is_empty() {
+                categories.push(ProgramCategory {
+                    name: cat_name,
+                    event_groups,
+                });
+            }
+        }
+
+        if !categories.is_empty() {
+            gender_groups.push(GenderGroup {
+                gender,
+                categories,
+            });
+        }
+    }
+
+    Ok(MobileCompetitionProgram { gender_groups })
+}

--- a/atletiek-nu-api/src/models/competitions_list_mobile.rs
+++ b/atletiek-nu-api/src/models/competitions_list_mobile.rs
@@ -1,0 +1,150 @@
+//! Parser for the mobile competition search endpoint:
+//! `athleteapp.php?page=events&do=searchresults`
+//!
+//! This endpoint is NOT protected by Cloudflare Turnstile, unlike `feeder.php`.
+//! It returns a list of competitions with id, name, date, location, registrations,
+//! club-only status, and WA recognition.
+//!
+//! HTML structure: `li > a[onclick] > div.item-inner > div.item-title > h6 (name)`
+
+use log::trace;
+use regex::Regex;
+use scraper::{Html, Selector};
+use serde::{Deserialize, Serialize};
+
+const REGEX_EVENT_ID: &str = r#"event_id=(\d+)"#;
+const REGEX_REGISTRATIONS: &str = r#"(\d+)\s*(?:registrations|athletes|deelnemers)"#;
+
+pub type MobileCompetitionsList = Vec<MobileCompetitionsListElement>;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MobileCompetitionsListElement {
+    pub id: u32,
+    pub name: String,
+    pub location: String,
+    pub date_display: String,
+    pub registrations: u32,
+    pub club_only: bool,
+    pub world_athletics_recognized: bool,
+    pub cancelled: bool,
+}
+
+pub fn parse(html: Html) -> anyhow::Result<MobileCompetitionsList> {
+    let li_sel = Selector::parse("li").unwrap();
+    let a_sel = Selector::parse("a").unwrap();
+    let title_sel = Selector::parse("div.item-title > h6").unwrap();
+    let subtitle_sel = Selector::parse("div.subtitle, div.item-footer").unwrap();
+    let club_only_sel = Selector::parse("span.clubmembersonly").unwrap();
+    let wa_sel = Selector::parse("img.WA-label").unwrap();
+    let calendar_header_sel = Selector::parse(".mini-calendar-header").unwrap();
+    let calendar_footer_sel = Selector::parse(".mini-calendar-footer").unwrap();
+
+    let re_event_id = Regex::new(REGEX_EVENT_ID).unwrap();
+    let re_registrations = Regex::new(REGEX_REGISTRATIONS).unwrap();
+
+    let mut result = Vec::new();
+
+    for li in html.select(&li_sel) {
+        // Skip group headers (month dividers)
+        let header_attr = li.value().attr("data-header-name");
+
+        let link = match li.select(&a_sel).next() {
+            Some(a) => a,
+            None => continue,
+        };
+
+        // Extract event_id from onclick
+        let onclick = link.value().attr("onclick").unwrap_or("");
+        let event_id = match re_event_id.captures(onclick) {
+            Some(cap) => match cap[1].parse::<u32>() {
+                Ok(id) => id,
+                Err(_) => continue,
+            },
+            None => continue,
+        };
+
+        // Cancelled?
+        let cancelled = link
+            .value()
+            .attr("class")
+            .map(|c| c.contains("cancelled"))
+            .unwrap_or(false);
+
+        // Name
+        let name = link
+            .select(&title_sel)
+            .next()
+            .map(|el| {
+                el.text()
+                    .filter(|t| !t.trim().is_empty())
+                    .next()
+                    .unwrap_or("")
+                    .trim()
+                    .to_string()
+            })
+            .unwrap_or_default();
+
+        if name.is_empty() {
+            trace!("Skipping competition with empty name (event_id={})", event_id);
+            continue;
+        }
+
+        // WA recognition
+        let world_athletics_recognized = link.select(&wa_sel).next().is_some();
+
+        // Club only
+        let club_only = link.select(&club_only_sel).next().is_some();
+
+        // Location & registrations from subtitle/footer
+        let mut location = String::new();
+        let mut registrations: u32 = 0;
+
+        for sub in link.select(&subtitle_sel) {
+            let text = sub.text().collect::<String>();
+            let text = text.trim().to_string();
+
+            if let Some(cap) = re_registrations.captures(&text) {
+                registrations = cap[1].parse().unwrap_or(0);
+            }
+
+            // Location is typically the subtitle text without registration count
+            if location.is_empty() && !text.is_empty() {
+                location = re_registrations.replace(&text, "").trim().to_string();
+                // Clean up trailing separators
+                location = location.trim_end_matches('|').trim().to_string();
+            }
+        }
+
+        // Date display from mini-calendar
+        let day_of_week = link
+            .select(&calendar_header_sel)
+            .next()
+            .map(|el| el.text().collect::<String>().trim().to_string())
+            .unwrap_or_default();
+        let day_number = link
+            .select(&calendar_footer_sel)
+            .next()
+            .map(|el| el.text().collect::<String>().trim().to_string())
+            .unwrap_or_default();
+
+        let date_display = if !day_of_week.is_empty() && !day_number.is_empty() {
+            let month = header_attr.unwrap_or("");
+            format!("{} {} {}", day_of_week, day_number, month)
+        } else {
+            String::new()
+        };
+
+        result.push(MobileCompetitionsListElement {
+            id: event_id,
+            name,
+            location,
+            date_display,
+            registrations,
+            club_only,
+            world_athletics_recognized,
+            cancelled,
+        });
+    }
+
+    Ok(result)
+}

--- a/atletiek-nu-api/src/models/mod.rs
+++ b/atletiek-nu-api/src/models/mod.rs
@@ -1,8 +1,10 @@
 pub mod athlete_event_result;
 pub mod athlete_list;
+pub mod athlete_profile;
+pub mod athlete_profile_mobile;
 pub mod competitions_list;
+pub mod competitions_list_mobile;
 pub mod competitions_list_web;
+pub mod competition_registrations_list;
 pub mod registrations_list;
 pub mod registrations_list_web;
-pub mod athlete_profile;
-pub mod competition_registrations_list;

--- a/atletiek-nu-api/src/models/mod.rs
+++ b/atletiek-nu-api/src/models/mod.rs
@@ -5,6 +5,8 @@ pub mod athlete_profile_mobile;
 pub mod competitions_list;
 pub mod competitions_list_mobile;
 pub mod competitions_list_web;
+pub mod competition_detail_mobile;
+pub mod competition_program_mobile;
 pub mod competition_registrations_list;
 pub mod registrations_list;
 pub mod registrations_list_web;


### PR DESCRIPTION
## Summary

- **Add mobile athlete profile endpoint** (`/mobile/athletes/profile/<id>`) — personal bests with full per-event performance history (wind, location, country, delta)
- **Add mobile competition search endpoint** (`/mobile/competitions/search`) — search by country, date range, and query
- **Add mobile competition detail endpoint** (`/mobile/competitions/detail/<id>`) — competition metadata, age group categories, events, pricing, and capacity
- **Add mobile competition program endpoint** (`/mobile/competitions/program/<id>`) — full program structure: gender → age category → event groups → events
- **Mobile endpoints (`athleteapp.php`) bypass Cloudflare Turnstile** which now blocks most web-facing endpoints

## Motivation

The athletics.app website now uses Cloudflare Turnstile anti-bot protection on web pages, causing `get_athlete_event_result`, `get_athlete_profile`, `get_competition_registrations_web`, and `search_competitions_for_time_period` to fail. The mobile app endpoints are unaffected and provide richer data.

## Web vs Mobile comparison

### Cloudflare status

| Endpoint | Type | Blocked |
|----------|------|---------|
| `/atleet/main/<id>/` | Web | ✅ Yes |
| `/atleet/profiel/<id>` | Web | ✅ Yes |
| `/wedstrijd/atleten/<id>/` | Web | ✅ Yes |
| `feeder.php?page=search&do=events` | Web | ✅ Yes |
| `athleteapp.php?page=athlete&do=records` | Mobile | ❌ No |
| `athleteapp.php?page=athlete&do=get` | Mobile | ❌ No |
| `athleteapp.php?page=events&do=searchresults` | Mobile | ❌ No |
| `athleteapp.php?page=event&do=get` | Mobile | ❌ No |
| `athleteapp.php?page=event&do=program` | Mobile | ❌ No |
| `athleteapp.php?page=athletes&do=searchresults` | Mobile | ❌ No (already used) |

### Athlete profile: data richness

| Data field | Web profile | Mobile profile |
|------------|:-----------:|:--------------:|
| Personal bests | ✅ | ✅ |
| Wind speed (PR) | ❌ | ✅ |
| Hand-measured flag | ❌ | ✅ |
| Indoor flag | ❌ | ✅ |
| Country code | ❌ | ✅ |
| Performance history | ⚠️ Float + date only | ✅ Full details |
| History: wind speed | ❌ | ✅ |
| History: location | ❌ | ✅ |
| History: country | ❌ | ✅ |
| History: progression delta | ❌ | ✅ |

### Competition search: data richness

| Data field | Web | Mobile |
|------------|:---:|:------:|
| Competition ID | ✅ | ✅ |
| Name | ✅ | ✅ |
| Location | ✅ | ✅ |
| Date | ✅ (NaiveDate) | ✅ (display string) |
| Registrations count | ❌ | ✅ |
| Club-only flag | ❌ | ✅ |
| WA recognized | ❌ | ✅ |
| Cancelled flag | ❌ | ✅ |
| Country filter | ❌ (NL hardcoded) | ✅ (parameter) |

### Competition detail (new — mobile only)

| Data field | Description |
|------------|-------------|
| Name | Competition name |
| Date | Date and time |
| Location | Venue and club |
| Country code | Extracted from flag image |
| Description | Competition description text |
| Federation recognized | Boolean flag |
| Categories | Age groups with their available event groups |
| Events per group | Individual events (e.g. 100m, 200m) |
| Pricing | Price per event group |
| Capacity info | Starting places and reserve places |

### Competition program (new — mobile only)

| Data field | Description |
|------------|-------------|
| Gender groups | Men / Women split |
| Categories per gender | Age groups (U9, U10, ..., Senior, Masters) |
| Event groups per category | Track Events, Field Events, Combined-events |
| Events per group | Individual events with full names |
| Pricing | Price per event group |
| Capacity | Starting places + reserve info |

### Endpoints with no mobile equivalent

| Web endpoint | Function | Status |
|--------------|----------|--------|
| `/atleet/main/<id>/` | `get_athlete_event_result` | ❌ No mobile alternative |
| `/wedstrijd/atleten/<id>/` | `get_competition_registrations_web` | ❌ Mobile `do=registrations` exists but returns less data |

## Changes

### New files
| File | Description |
|------|-------------|
| `atletiek-nu-api/src/models/athlete_profile_mobile.rs` | HTML parser for mobile athlete records (PRs + history) |
| `atletiek-nu-api/src/models/competitions_list_mobile.rs` | HTML parser for mobile competition search results |
| `atletiek-nu-api/src/models/competition_detail_mobile.rs` | HTML parser for mobile competition detail (categories table) |
| `atletiek-nu-api/src/models/competition_program_mobile.rs` | HTML parser for mobile competition program (accordion structure) |

### Modified files
| File | Change |
|------|--------|
| `atletiek-nu-api/src/lib.rs` | `get_athlete_profile_mobile()`, `search_competitions_mobile()`, `get_competition_detail_mobile()`, `get_competition_program_mobile()` |
| `atletiek-nu-api/src/models/mod.rs` | Register new parser modules |
| `api/src/route.rs` | New Rocket routes under `/mobile/` |
| `api/src/cache/mod.rs` | New `CachedRequest` variants (12h cache) |
| `api/src/main.rs` | Mount new routes |
| `api-cfworker/src/lib.rs` | New Cloudflare Worker routes |
| `README.md` | Full endpoint documentation with comparison tables |

## API endpoints

### `GET /mobile/athletes/profile/<id>`
Returns personal bests with per-event performance history including wind speed, location, country code, and delta.

### `GET /mobile/competitions/search?country=NL&start=YYYY-MM-DD&end=YYYY-MM-DD&query=text`
Search competitions by country and date range.

### `GET /mobile/competitions/detail/<id>` (new)
Returns competition metadata (name, date, location, description) and the categories table showing which age groups can participate with their available events, pricing, and capacity.

### `GET /mobile/competitions/program/<id>` (new)
Returns the full competition program: gender groups → age categories → event groups → individual events. More detailed than the detail endpoint — includes the complete program breakdown.

## Test plan

- [x] `cargo build -p atletiek_nu_api -p api` compiles with no errors
- [x] `cargo check` on the Cloudflare worker compiles with no errors
- [x] Test `/mobile/athletes/profile/864789` returns valid JSON
- [x] Test `/mobile/competitions/search?country=NL&start=2024-01-01&end=2024-12-31` returns competition list
- [x] Test `/mobile/competitions/detail/43958` returns competition categories and metadata
- [x] Test `/mobile/competitions/program/43958` returns full program structure
- [x] Verify existing endpoints are unaffected
- [x] Deploy Cloudflare worker — all endpoints verified live

🤖 Generated with [Claude Code](https://claude.com/claude-code)